### PR TITLE
Fixed Heroku deployment issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/go-phie/gophie
 
+// +heroku goVersion go1.16
 go 1.16
 
 require (


### PR DESCRIPTION
Go version defaults to go1.12.17 when trying to deploy on Heroku and causes the build to fail.
Adding `// +heroku goVersion <version>` solves it.