### PR TITLE
FIX: panic: runtime error: index out of range [2] with length 1

### DIFF
--- a/engine/netnaija.go
+++ b/engine/netnaija.go
@@ -124,7 +124,9 @@ func (engine *NetNaijaEngine) parseSingleMovie(el *colly.HTMLElement, index int)
 // SabiShare Token are usually in the URL in the form https://www.sabishare.com/file/<TOKEN>-<remaining-url>
 func (engine *NetNaijaEngine) getDownloadToken(sabiShareURL string) string {
 	cleanURL, _ := url.Parse(sabiShareURL)
-	return strings.Split(strings.Split(cleanURL.Path, "-")[0], "/")[2]
+	partsSplitByDash := strings.Split(cleanURL.Path, "-")[0]
+	partsSplitBySlash := strings.Split(partsSplitByDash, "/")
+	return partsSplitBySlash[len(partsSplitBySlash)-1]
 }
 
 func (engine *NetNaijaEngine) updateDownloadProps(downloadCollector *colly.Collector, movies *[]Movie) {


### PR DESCRIPTION
go run main.go search "the orville season 1"
⣷ Fetching Data... panic: runtime error: index out of range [2] with length 1

goroutine 1 [running]:
github.com/go-phie/gophie/engine.(*NetNaijaEngine).getDownloadToken(0x0?, {0x0?, 0xc000249cc0?})
        /home/codeliger/go/src/github.com/codeliger/gophie/engine/netnaija.go:127 +0x98